### PR TITLE
Moved FileZilla out of Mozilla in projects.json

### DIFF
--- a/src/projects.json
+++ b/src/projects.json
@@ -64,11 +64,6 @@
 					"type": "compressed",
 					"target": "gaia.zip"
 				},
-				"filezilla": {
-					"url" : "http://pootle.softcatala.org/ca/filezilla/export/zip",
-					"type": "compressed",
-					"target": "filezilla.zip"
-				},
 				"mozilla-addons": {
 					"url" : "http://localize.mozilla.org/ca/amo/export/zip",
 					"type": "compressed",
@@ -103,6 +98,16 @@
 					"url" : "http://localize.mozilla.org/ca/sumo/export/zip",
 					"type": "compressed",
 					"target": "sumo.zip"
+				}
+			}
+		},
+		"filezilla": {
+			"filename" : "filezilla-tm.po",
+			"fileset": {
+				"filezilla": {
+					"url" : "http://pootle.softcatala.org/ca/filezilla/export/zip",
+					"type": "compressed",
+					"target": "filezilla.zip"
 				}
 			}
 		},


### PR DESCRIPTION
Despite its name, FileZilla has no relation with any Mozilla product, so I've created a new `project` in `projects.json`
