### PR TITLE
pep8

### DIFF
--- a/src/localdirfileset.py
+++ b/src/localdirfileset.py
@@ -16,16 +16,19 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-from fileset import *
+from fileset import FileSet
+
+import os
+
 
 class LocalDirFileSet(FileSet):
 
-	def Do(self):
+    def Do(self):
 
-		os.system("rm -f " + self.temp_dir)
-		os.system("mkdir " + self.temp_dir)
-		os.system("cp " + self.url + " " + self.temp_dir +  "/" + self.filename)
+        os.system("rm -f " + self.temp_dir)
+        os.system("mkdir " + self.temp_dir)
+        os.system("cp " + self.url + " " + self.temp_dir + "/" + self.filename)
 
-		self.ConvertTsFilesToPo()
-		self.AddComments()
-		self.Build()
+        self.ConvertTsFilesToPo()
+        self.AddComments()
+        self.Build()

--- a/src/localfileset.py
+++ b/src/localfileset.py
@@ -16,17 +16,20 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-from fileset import *
+from fileset import FileSet
+
+import os
+
 
 class LocalFileSet(FileSet):
 
-	def Do(self):
+    def Do(self):
 
-		os.system("cp " + self.url + " " + self.filename)
+        os.system("cp " + self.url + " " + self.filename)
 
-		self.Uncompress()
-		self.ConvertTsFilesToPo()
-		self.AddComments()
-		self.Build()
+        self.Uncompress()
+        self.ConvertTsFilesToPo()
+        self.AddComments()
+        self.Build()
 
-		os.system("rm -f " + self.filename)
+        os.system("rm -f " + self.filename)


### PR DESCRIPTION
translation-memory-tools claims on its README that the coding style used is `pep8` and that's great news!

Still a run of `flake8` on the src folder reveals quite a few mistakes... nearly 500 actually.

The most offending thing being using tabs instead of 4 spaces.

The attached commit is just a pep8ify of the shortest files, as a proof.

If there's really a desire of trying to enforce pep8 I can happily go over all the files and put them together beautifully.

Note that `CamelCase` synatx for naming is discouraged and non_camel_case naming is preferred. This would involve rewriting nearly all code to use this convention... how far do we want to enforce pep8? (that's an open question :)
