### PR TITLE
Add TERMCAT Centre de Terminologia (2017) data licensed under CC BY

### DIFF
--- a/cfg/projects/Termcat-CCBY.json
+++ b/cfg/projects/Termcat-CCBY.json
@@ -1,0 +1,11 @@
+{
+    "project": "Termcat-CCBY", 
+    "projectweb": "http://www.termcat.cat/ca/TerminologiaOberta", 
+    "fileset": {
+        "mame": {
+            "url": "https://raw.githubusercontent.com/pereorga/termcat-dicts/master/termcat_ccby.po",
+            "type": "file", 
+            "target": "ca.po"
+        }
+    }
+}

--- a/cfg/projects/Termcat-CCBY.json
+++ b/cfg/projects/Termcat-CCBY.json
@@ -2,7 +2,7 @@
     "project": "Termcat-CCBY", 
     "projectweb": "http://www.termcat.cat/ca/TerminologiaOberta", 
     "fileset": {
-        "mame": {
+        "termcat-ccby": {
             "url": "https://raw.githubusercontent.com/pereorga/termcat-dicts/master/termcat_ccby.po",
             "type": "file", 
             "target": "ca.po"


### PR DESCRIPTION
This is to add all CC BY data from http://termcat.cat/ca/TerminologiaOberta

Only CC BY 3.0 entries are included. Note that most files available in http://termcat.cat/ca/TerminologiaOberta are released under CC BY ND, which is not suitable for reuse (but it may be for reference).

My original idea was to create dictd files from this data, and I guess TerminologiaOberta data could also be used in https://github.com/Softcatala/diccionari-multilingue and other open dictionaries (Viccionari?), but as far as I can see no one has done it before.

Also, because a single file is created, repeated entries from different contexts are lost. The alternative would have been importing a dozen of different PO files here.

A veure si funciona, no he arribat a instal·lar translation-memory-tools en local però el fitxer PO és vàlid.