### PR TITLE
Add xfe file manager

### DIFF
--- a/cfg/projects/xfe.json
+++ b/cfg/projects/xfe.json
@@ -1,0 +1,11 @@
+{
+    "project": "xfe",
+    "projectweb": "http://roland65.free.fr/xfe/",
+    "fileset": {
+        "xfe": {
+            "url": "https://salsa.debian.org/joowie-guest/maintain_xfe/blob/master/po/ca.po", 
+            "type": "file",
+            "target": "xfe-ca.po"
+        }
+    }
+}


### PR DESCRIPTION
_xfe_ file manager does not provide a git repository, but Debian maintains its own.

Current xfe translation to Catalan is not very good at this moment, but I plan to improve it soon.