### PR TITLE
Windows Calculator: nou projecte

### DIFF
--- a/cfg/projects/WindowsCalculator.json
+++ b/cfg/projects/WindowsCalculator.json
@@ -1,0 +1,12 @@
+{
+    "project": "WindowsCalculator",
+    "projectweb": "https://github.com/microsoft/calculator",
+    "fileset": {
+        "WindowsCalculator": {
+            "url": "https://github.com/pereorga/software-translations.git",
+            "type": "git",
+            "duplicates" : "msgctxt",
+            "pattern": ".*?/calc/.*?"
+        }
+    }
+}

--- a/cfg/projects/WindowsCalculator.json
+++ b/cfg/projects/WindowsCalculator.json
@@ -2,11 +2,11 @@
     "project": "WindowsCalculator",
     "projectweb": "https://github.com/microsoft/calculator",
     "fileset": {
-        "WindowsCalculator": {
-            "url": "https://github.com/pereorga/software-translations.git",
-            "type": "git",
+        "calc": {
+            "url": "https://raw.githubusercontent.com/pereorga/software-translations/master/calc/ca.po",
+            "type": "file",
             "duplicates" : "msgctxt",
-            "pattern": ".*?/calc/.*?"
+            "target": "calc-ca.po"
         }
     }
 }


### PR DESCRIPTION
Com que no sé si el sistema suporta el format resw (no he trobat exemples al repositori), ho poso de moment al meu repositori intermedi. Jo he fet servir [resx2po](https://github.com/pereorga/software-translations/blob/master/calc/generate.sh), que està al Translate Toolkit.

Aquest projecte tot i ser de Microsoft, té llicència MIT. És especialment interessant per les traduccions d'unitats.

