### PR TITLE
Fine tunning Freedesktop and Mediawiki translations download

### DIFF
--- a/cfg/projects/Debian.json
+++ b/cfg/projects/Debian.json
@@ -8,7 +8,7 @@
             "target": "apt-ca.po"  
         },
         "dpkg": {
-            "url": "https://salsa.debian.org/dpkg-team/dpkg/raw/master/po/ca.po", 
+            "url": "https://salsa.debian.org/dpkg-team/dpkg/-/raw/main/po/ca.po", 
             "type": "file", 
             "target": "dpkg-ca.po"       
         },

--- a/cfg/projects/Freedesktop.json
+++ b/cfg/projects/Freedesktop.json
@@ -17,8 +17,9 @@
             "type": "transifex"
         },
         "fprintd": {
-            "url": "https://www.transifex.com/projects/p/fprintd",
-            "type": "transifex"
+            "url": "https://gitlab.freedesktop.org/libfprint/fprintd/-/raw/master/po/ca.po",
+            "type": "file",
+            "target": "fprintd.po"
         },
         "p11-kit": {
             "url": "https://www.transifex.com/projects/p/p11-kit",

--- a/cfg/projects/Mediawiki.json
+++ b/cfg/projects/Mediawiki.json
@@ -8,7 +8,7 @@
             "target": "main-ca.po"
         }, 
         "mobile-app": {
-            "url": "https://translatewiki.net/wiki/Special:ExportTranslations?group=ext-mobileapp&language=ca&format=export-to-file",
+            "url": "https://translatewiki.net/wiki/Special:ExportTranslations?group=ext-mobileapp&language=ca&format=export-as-po",
             "type": "file",
             "target": "mobile-app.po"
         },
@@ -28,7 +28,7 @@
             "target": "wikipedia-android.po"
         },
         "extensions": {
-            "url": "https://translatewiki.net/w/i.php?title=Special:Translate&taction=export&group=ext-0-all&language=ca&task=export-as-po",
+            "url": "https://translatewiki.net/w/i.php?title=Special:Translate&action=export&group=ext-0-all&language=ca&task=export-as-po",
             "type": "file", 
             "target": "extensions-ca.po"
         }


### PR DESCRIPTION
Fix 3 errors downloading translations:
- File "fprintd" from Freedesktop project
- Files "ext-mobileapp" and "extensions" from Mediawiki project.