### PR TITLE
Change in the severity for 404 HTML code

### DIFF
--- a/src/builder/weblatefileset.py
+++ b/src/builder/weblatefileset.py
@@ -133,7 +133,10 @@ class WeblateFileSet(FileSet):
             return True
 
         except Exception as detail:
-            logging.error("WeblateFileSet._get_file {0} - error: {1}".format(url, detail))
+            if detail.code == 404:
+                logging.info("WeblateFileSet._get_file {0} - info: {1}".format(url, detail))
+            else:
+                logging.error("WeblateFileSet._get_file {0} - error: {1}".format(url, detail))
             return False
 
     def do(self):


### PR DESCRIPTION
Checking for Catalan translation is done at domain level. But a domain have some files (one or more). If a file of a domain is not translated, this file doesn't exist and we obtain a 404 HTML code. With this PR, I suggest a change in the severity for 404 HTML code, from error to info severity. This will help to maintain clean the error log, while we will see not found files in the info log.