### PR TITLE
WinMerge: actualitzo URL i torno a habilitar

### DIFF
--- a/cfg/projects/WinMerge.json
+++ b/cfg/projects/WinMerge.json
@@ -4,11 +4,9 @@
     "projectweb": "https://winmerge.org/translations/",
     "fileset": {
         "WinMerge": {
-            "url": "https://raw.githubusercontent.com/WinMerge/winmerge-v2/master/Translations/WinMerge/Catalan.po",
+            "url": "https://raw.githubusercontent.com/WinMerge/winmerge/master/Translations/WinMerge/Catalan.po",
             "type": "file", 
             "target": "winmerge-ca.po"
         }
-    },
-    "disabled": true,
-    "comment": "Invalid PO file at the moment"
+    }
 }


### PR DESCRIPTION
Actualitzo l'URL al repositori correcte (l'altre és un fork que ja no s'actualitza)

No he vist res malament al fitxer, pel que veig és un fitxer gettext vàlid, msgattrib funciona.

No ho he pogut provar (estic en mac, sense un linux a prop) però no veig res que podria fer-ho fallar, així que el torno a habilitar.