### PR TITLE
RawTherapee: nou projecte

### DIFF
--- a/cfg/projects/RawTherapee.json
+++ b/cfg/projects/RawTherapee.json
@@ -1,0 +1,12 @@
+{
+    "project": "RawTherapee",
+    "license" : "GPL-3.0-or-later",
+    "projectweb": "https://rawpedia.rawtherapee.com/Translating_RawTherapee",
+    "fileset": {
+        "RawTherapee": {
+            "url": "https://raw.githubusercontent.com/pereorga/software-translations/master/rawtherapee/ca.po",
+            "type": "file",
+            "target": "rawtherapee-ca.po"
+        }
+    }
+}


### PR DESCRIPTION
Crec que és un projecte que ens interessa tenir a les memòries (i a l'informe d'errors).

El poso a través del repositori intermedi. Fa servir fitxers pseudo-csv (més detalls a https://github.com/pereorga/software-translations/blob/master/rawtherapee/generate.sh)