### PR TITLE
muCommander: nou projecte

### DIFF
--- a/cfg/projects/muCommander.json
+++ b/cfg/projects/muCommander.json
@@ -1,0 +1,12 @@
+{
+    "project": "muCommander",
+    "license" : "GPL-3.0-or-later",
+    "projectweb": "https://github.com/mucommander/mucommander/wiki/Translate",
+    "fileset": {
+        "muCommander": {
+            "url": "https://raw.githubusercontent.com/pereorga/software-translations/master/mucommander/dictionary_ca.po",
+            "type": "file",
+            "target": "mucommander-ca.po"
+        }
+    }
+}


### PR DESCRIPTION
Això idealment s'hauria d'integrar directament. He trobat codi a src/builder/convertfiles.py que aparentment ha de servir per convertir fitxers properties (utilitzant Translate Toolkit) però no em queda clar que funcioni, ni he trobat exemples que ho facin servir.

L'ordre a executar hauria de ser molt simple (especificar la codificació sembla que és necessari): https://github.com/pereorga/software-translations/blob/master/mucommander/generate.sh#L6