### PR TITLE
MediaWiki: suprimeixo mediawiki.po (és massa gros) i afegeixo mediawiki-exif

### DIFF
--- a/cfg/projects/MediaWiki.json
+++ b/cfg/projects/MediaWiki.json
@@ -58,10 +58,10 @@
             "type": "file",
             "target": "wikimedia-media.po"
         },
-        "mediawiki": {
-            "url": "https://translatewiki.net/wiki/Special:ExportTranslations?group=mediawiki&language=ca&format=export-as-po",
+        "mediawiki-exif": {
+            "url": "https://translatewiki.net/wiki/Special:ExportTranslations?group=mediawiki-exif&language=ca&format=export-as-po",
             "type": "file",
-            "target": "mediawiki.po"
+            "target": "mediawiki-exif.po"
         },
         "wikipedia-library-website": {
             "url": "https://translatewiki.net/wiki/Special:ExportTranslations?group=wikipedia-library-website&language=ca&format=export-as-po",


### PR DESCRIPTION
mediawiki.po no baixa perquè és massa gros (surt com a error al log), i ara la majoria d'ell ja està inclòs en fitxers més petits.
mediawiki-exif és un altre fitxer interessant