### PR TITLE
docs(README): provide installation steps on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,21 @@ If you use docker locally or in production, these credetials are configured in a
 
 This part focuses on helping run to the *builder* component locally if you want to quickly new projects configurations. For any other use case, we recommend using the Docker.
 
+Debian:
+
 ```shell
 sudo apt-get update -y && sudo apt-get install python3-dev libhunspell-dev libyaml-dev gettext zip mercurial bzr ruby git curl wget g++ subversion bzip2 python2-dev -y
 curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash && mv ./tx /usr/bin/
 sudo gem install i18n-translators-tools
+pip install -r requirements.txt
+```
 
-cd translation-memory-tools
+macOS:
+
+```shell
+brew install python3 breezy hunspell libyaml gettext zip mercurial ruby git curl wget gcc subversion bzip2
+curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash && mv ./tx /usr/bin/
+sudo gem install i18n-translators-tools
 pip install -r requirements.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Debian:
 
 ```shell
 sudo apt-get update -y && sudo apt-get install python3-dev libhunspell-dev libyaml-dev gettext zip mercurial bzr ruby git curl wget g++ subversion bzip2 python2-dev -y
-curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash && mv ./tx /usr/bin/
+curl https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash && mv ./tx /usr/bin/
 sudo gem install i18n-translators-tools
 pip install -r requirements.txt
 ```
@@ -54,7 +54,7 @@ macOS:
 
 ```shell
 brew install python3 breezy hunspell libyaml gettext zip mercurial ruby git curl wget gcc subversion bzip2
-curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash && mv ./tx /usr/bin/
+curl https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 sudo gem install i18n-translators-tools
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
L'ordre d'exemple s'executa correctament: `./builder.py -p Abiword`

L'ordre pip encara dona un error en instal·lar els requisits, però no he trobat com resoldre-ho:

```
$ pip install -r requirements.txt
Requirement already satisfied: polib==1.1.1 in /opt/homebrew/lib/python3.10/site-packages (from -r requirements.txt (line 2)) (1.1.1)
Collecting pystache
  Using cached pystache-0.6.0-py3-none-any.whl
Requirement already satisfied: peewee==3.14.8 in /opt/homebrew/lib/python3.10/site-packages (from -r requirements.txt (line 4)) (3.14.8)
Collecting hunspell
  Using cached hunspell-0.5.5.tar.gz (34 kB)
  Preparing metadata (setup.py) ... done
Collecting phply
  Using cached phply-1.2.6-py2.py3-none-any.whl (74 kB)
Collecting translate-toolkit==3.3.4
  Using cached translate_toolkit-3.3.4-py3-none-any.whl
Collecting lxml
  Using cached lxml-4.9.2-cp310-cp310-macosx_12_0_arm64.whl
Requirement already satisfied: pyyaml>=5.1 in /opt/homebrew/lib/python3.10/site-packages (from -r requirements.txt (line 9)) (6.0)
Collecting android2po==1.6.0
  Using cached android2po-1.6.0-py3-none-any.whl
Requirement already satisfied: Whoosh in /opt/homebrew/lib/python3.10/site-packages (from -r requirements.txt (line 13)) (2.7.4)
Requirement already satisfied: pytest in /opt/homebrew/lib/python3.10/site-packages (from -r requirements.txt (line 16)) (7.1.3)
Requirement already satisfied: flake8 in /opt/homebrew/lib/python3.10/site-packages (from -r requirements.txt (line 17)) (5.0.4)
Requirement already satisfied: nose2 in /opt/homebrew/lib/python3.10/site-packages (from -r requirements.txt (line 18)) (0.12.0)
Collecting babel
  Using cached Babel-2.11.0-py3-none-any.whl (9.5 MB)
Collecting colorama
  Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting termcolor
  Using cached termcolor-2.2.0-py3-none-any.whl (6.6 kB)
Collecting argparse
  Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Requirement already satisfied: ply in /opt/homebrew/lib/python3.10/site-packages (from phply->-r requirements.txt (line 6)) (3.11)
Requirement already satisfied: iniconfig in /opt/homebrew/lib/python3.10/site-packages (from pytest->-r requirements.txt (line 16)) (1.1.1)
Requirement already satisfied: py>=1.8.2 in /opt/homebrew/lib/python3.10/site-packages (from pytest->-r requirements.txt (line 16)) (1.11.0)
Requirement already satisfied: pluggy<2.0,>=0.12 in /opt/homebrew/lib/python3.10/site-packages (from pytest->-r requirements.txt (line 16)) (1.0.0)
Requirement already satisfied: packaging in /opt/homebrew/lib/python3.10/site-packages (from pytest->-r requirements.txt (line 16)) (21.3)
Requirement already satisfied: tomli>=1.0.0 in /opt/homebrew/lib/python3.10/site-packages (from pytest->-r requirements.txt (line 16)) (2.0.1)
Requirement already satisfied: attrs>=19.2.0 in /opt/homebrew/lib/python3.10/site-packages (from pytest->-r requirements.txt (line 16)) (22.1.0)
Requirement already satisfied: pyflakes<2.6.0,>=2.5.0 in /opt/homebrew/lib/python3.10/site-packages (from flake8->-r requirements.txt (line 17)) (2.5.0)
Requirement already satisfied: mccabe<0.8.0,>=0.7.0 in /opt/homebrew/lib/python3.10/site-packages (from flake8->-r requirements.txt (line 17)) (0.7.0)
Requirement already satisfied: pycodestyle<2.10.0,>=2.9.0 in /opt/homebrew/lib/python3.10/site-packages (from flake8->-r requirements.txt (line 17)) (2.9.1)
Requirement already satisfied: pytz>=2015.7 in /opt/homebrew/lib/python3.10/site-packages (from babel->android2po==1.6.0->-r requirements.txt (line 10)) (2022.4)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/homebrew/lib/python3.10/site-packages (from packaging->pytest->-r requirements.txt (line 16)) (3.0.9)
Building wheels for collected packages: hunspell
  Building wheel for hunspell (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [12 lines of output]
      running bdist_wheel
      running build
      running build_ext
      building 'hunspell' extension
      creating build
      creating build/temp.macosx-12-arm64-cpython-310
      clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -D_LINUX -I/usr/local/Cellar/hunspell/1.6.2/include/hunspell -I/opt/homebrew/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/include/python3.10 -c hunspell.cpp -o build/temp.macosx-12-arm64-cpython-310/hunspell.o -Wall
      hunspell.cpp:20:10: fatal error: 'hunspell.hxx' file not found
      #include <hunspell.hxx>
               ^~~~~~~~~~~~~~
      1 error generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for hunspell
  Running setup.py clean for hunspell
Failed to build hunspell
Installing collected packages: hunspell, argparse, termcolor, pystache, phply, lxml, colorama, babel, translate-toolkit, android2po
  Running setup.py install for hunspell ... error
  error: subprocess-exited-with-error

  × Running setup.py install for hunspell did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      running install
      /opt/homebrew/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      running build
      running build_ext
      building 'hunspell' extension
      creating build
      creating build/temp.macosx-12-arm64-cpython-310
      clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -D_LINUX -I/usr/local/Cellar/hunspell/1.6.2/include/hunspell -I/opt/homebrew/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/include/python3.10 -c hunspell.cpp -o build/temp.macosx-12-arm64-cpython-310/hunspell.o -Wall
      hunspell.cpp:20:10: fatal error: 'hunspell.hxx' file not found
      #include <hunspell.hxx>
               ^~~~~~~~~~~~~~
      1 error generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> hunspell

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
```

