### PR TITLE
CKEditor: nou projecte

### DIFF
--- a/cfg/projects/CKEditor.json
+++ b/cfg/projects/CKEditor.json
@@ -1,0 +1,12 @@
+{
+    "project": "CKEditor",
+    "license" : "GPL-2.0-or-later",
+    "projectweb": "https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/ui/localization.html",
+    "fileset": {
+        "ckeditor": {
+            "url": "https://github.com/ckeditor/ckeditor5.git",
+            "type": "git",
+            "pattern": ".*?ca.po"
+        }
+    }
+}


### PR DESCRIPTION
Aquest projecte ja havia existit a les memòries (a través de Transifex) però es va suprimir.

Aquesta PR funciona, tot i que el procés es torna una mica boig intentant convertir els fitxers amb extensió TS (TypeScript) a PO, quan en realitat el que hauria de fer només és importar tots els fitxers PO existents. Sembla que el problema és que s'executa la funció _convert_ts_files_to_po, fins i tot encara que li hagi indicat un patró que inclogui només els fitxers .po.

Potser, tot i que el "type" sigui "git", s'hauria de poder indicar el format dels fitxers d'origen. En general, els repositoris només contindran un sol format (Gettext, TS, etc) i es podria especificar manualment. Ara bé, m'imagino que hi pot haver projectes que depenguin en el comportament actual. L'extensió ts per TypeScript serà cada vegada més comuna.

