### PR TITLE
Clementine: new project

### DIFF
--- a/cfg/projects/Clementine.json
+++ b/cfg/projects/Clementine.json
@@ -1,0 +1,17 @@
+{
+    "project": "Clementine",
+    "license" : "GPL-3.0-or-later",
+    "projectweb": "https://www.clementine-player.org/",
+    "fileset": {
+        "clementine": {
+            "url": "https://raw.githubusercontent.com/clementine-player/Clementine/master/src/translations/ca.po",
+            "type": "file", 
+            "target": "clementine-ca.po"
+        },
+        "strawberry": {
+            "url": "https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/master/src/translations/ca.po",
+            "type": "file", 
+            "target": "strawberry-ca.po"
+        }
+    }
+}


### PR DESCRIPTION
Afegeixo també les traduccions de [Strawberry Music Player](https://www.strawberrymusicplayer.org/), un fork de Clementine. Potser més endavant se'n pot esborrar un o separar els projectes en 2 fitxers, ara per ara tots dos semblen mantinguts.