### PR TITLE
docs(README): call pip3 rather than pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Debian:
 sudo apt-get update -y && sudo apt-get install python3-dev libhunspell-dev libyaml-dev gettext zip mercurial bzr ruby git curl wget g++ subversion bzip2 python2-dev -y
 curl https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash && mv ./tx /usr/bin/
 sudo gem install i18n-translators-tools
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 macOS:
@@ -56,7 +56,7 @@ macOS:
 brew install python3 breezy hunspell libyaml gettext zip mercurial ruby git curl wget gcc subversion bzip2
 curl https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 sudo gem install i18n-translators-tools
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 For example, to download only the Abiword project:


### PR DESCRIPTION
This fixes installation on Ubuntu 22.04