### PR TITLE
Add additional files for VLC and SuperTux projects

### DIFF
--- a/cfg/projects/SuperTux.json
+++ b/cfg/projects/SuperTux.json
@@ -7,6 +7,36 @@
             "url": "https://raw.githubusercontent.com/SuperTux/supertux/master/data/locale/ca.po",
             "type": "file",
             "target": "supertux-ca.po"
+        },
+        "SuperTux-bonus1": {
+            "url": "https://raw.githubusercontent.com/SuperTux/supertux/master/data/levels/bonus1/ca.po",
+            "type": "file",
+            "target": "supertux-bonus1-ca.po"
+        },
+        "SuperTux-bonus2": {
+            "url": "https://raw.githubusercontent.com/SuperTux/supertux/master/data/levels/bonus2/ca.po",
+            "type": "file",
+            "target": "supertux-bonus2-ca.po"
+        },
+        "SuperTux-bonus3": {
+            "url": "https://raw.githubusercontent.com/SuperTux/supertux/master/data/levels/bonus3/ca.po",
+            "type": "file",
+            "target": "supertux-bonus3-ca.po"
+        },
+        "SuperTux-world1": {
+            "url": "https://raw.githubusercontent.com/SuperTux/supertux/master/data/levels/world1/ca.po",
+            "type": "file",
+            "target": "supertux-world1-ca.po"
+        },
+        "SuperTux-world2": {
+            "url": "https://raw.githubusercontent.com/SuperTux/supertux/master/data/levels/world2/ca.po",
+            "type": "file",
+            "target": "supertux-world2-ca.po"
+        },
+        "SuperTux-halloween2014": {
+            "url": "https://raw.githubusercontent.com/SuperTux/supertux/master/data/levels/halloween2014/ca.po",
+            "type": "file",
+            "target": "supertux-halloween2014-ca.po"
         }
     }
 }

--- a/cfg/projects/VLC.json
+++ b/cfg/projects/VLC.json
@@ -8,6 +8,11 @@
             "url": "https://code.videolan.org/videolan/vlc/-/raw/master/po/ca.po",
             "type": "file",
             "target": "vlc-ca.po"
+        },
+        "VLMC": {
+            "url": "https://code.videolan.org/videolan/vlmc/-/raw/master/ts/vlmc_ca_ES.ts",
+            "type": "file",
+            "target": "vlmc-ca.ts"
         }
     }
 }


### PR DESCRIPTION
Afegeixo fitxers de traducció addicionals.

En el cas de VLC, afegeixo el projecte VLMC. M'agradaria incloure les traduccions d'Android i iPhone, però no estic segur que suportem els seus formats (.strings i strings.xml):

- https://code.videolan.org/videolan/vlc-android/-/tree/master/application/resources/src/main/res/values-ca
- https://code.videolan.org/videolan/vlc-ios/-/tree/master/Resources/ca.lproj

En el cas del SuperTux, afegeixo traduccions dels nivells. Si de Transifex en venien més, no entenc d'on podien sortir, potser de versions antigues.