### PR TITLE
refactor: move DjangoCMS and GNUSocial from Transifex

### DIFF
--- a/cfg/projects/DjangoCMS.json
+++ b/cfg/projects/DjangoCMS.json
@@ -6,7 +6,7 @@
         "DjangoCMS": {
             "url": "https://github.com/django-cms/django-cms.git",
             "type": "git",
-            "pattern": ".*\/ca\/.*\\.po"
+            "pattern": ".*/ca/.*\\.po"
         }
     }
 }

--- a/cfg/projects/DjangoCMS.json
+++ b/cfg/projects/DjangoCMS.json
@@ -4,8 +4,9 @@
     "projectweb": "https://www.django-cms.org/",
     "fileset": {
         "DjangoCMS": {
-            "url": "https://app.transifex.com/divio/django-cms/",
-            "type": "transifex"
+            "url": "https://github.com/django-cms/django-cms.git",
+            "type": "git",
+            "pattern": ".*?/ca/.*?"
         }
     }
 }

--- a/cfg/projects/DjangoCMS.json
+++ b/cfg/projects/DjangoCMS.json
@@ -6,7 +6,7 @@
         "DjangoCMS": {
             "url": "https://github.com/django-cms/django-cms.git",
             "type": "git",
-            "pattern": ".*?/ca/.*?"
+            "pattern": ".*\/ca\/.*po"
         }
     }
 }

--- a/cfg/projects/DjangoCMS.json
+++ b/cfg/projects/DjangoCMS.json
@@ -6,7 +6,7 @@
         "DjangoCMS": {
             "url": "https://github.com/django-cms/django-cms.git",
             "type": "git",
-            "pattern": ".*\/ca\/.*po"
+            "pattern": ".*\/ca\/.*\\.po"
         }
     }
 }

--- a/cfg/projects/GNUSocial.json
+++ b/cfg/projects/GNUSocial.json
@@ -4,8 +4,9 @@
     "projectweb": "https://www.gnusocial.rocks/", 
     "fileset": {
         "GNUSocial": {
-            "url": "https://app.transifex.com/gnu-social/gnu-social/",
-            "type": "transifex"
+            "url": "https://notabug.org/diogo/gnu-social/raw/master/locale/ca/LC_MESSAGES/statusnet.po",
+            "type": "file",
+            "target": "GNUSocial-ca.po"
         }
     }
 }

--- a/cfg/projects/GNUSocial.json
+++ b/cfg/projects/GNUSocial.json
@@ -4,9 +4,9 @@
     "projectweb": "https://www.gnusocial.rocks/", 
     "fileset": {
         "GNUSocial": {
-            "url": "https://notabug.org/diogo/gnu-social/raw/master/locale/ca/LC_MESSAGES/statusnet.po",
-            "type": "file",
-            "target": "GNUSocial-ca.po"
+            "url": "https://notabug.org/diogo/gnu-social.git",
+            "type": "git",
+            "pattern": ".*\/ca\/.*po"
         }
     }
 }

--- a/cfg/projects/GNUSocial.json
+++ b/cfg/projects/GNUSocial.json
@@ -6,7 +6,7 @@
         "GNUSocial": {
             "url": "https://notabug.org/diogo/gnu-social.git",
             "type": "git",
-            "pattern": ".*\/ca\/.*po"
+            "pattern": ".*\/ca\/.*\\.po"
         }
     }
 }

--- a/cfg/projects/GNUSocial.json
+++ b/cfg/projects/GNUSocial.json
@@ -6,7 +6,7 @@
         "GNUSocial": {
             "url": "https://notabug.org/diogo/gnu-social.git",
             "type": "git",
-            "pattern": ".*\/ca\/.*\\.po"
+            "pattern": ".*/ca/.*\\.po"
         }
     }
 }


### PR DESCRIPTION
De GNUSocial surten menys cadenes, però sembla que siguin totes. El projecte sembla força inactiu de totes maneres