### PR TITLE
Draft: move Kodi from Transifex

### DIFF
--- a/cfg/projects/Kodi.json
+++ b/cfg/projects/Kodi.json
@@ -6,7 +6,17 @@
         "kodi-main": {
             "url": "https://github.com/xbmc/xbmc.git",
             "type": "git",
-            "pattern": ".*?/resource.language.ca_es/strings.po"
+            "pattern": ".*\/resource\\.language\\.ca_es\/strings.po"
+        },
+        "kodi-main2": {
+            "url": "https://github.com/xbmc/xbmc.git",
+            "type": "git",
+            "pattern": ".*\/language\/Catalan\/strings.po"
+        },
+        "kodi-confluence": {
+            "url": "https://raw.githubusercontent.com/xbmc/skin.confluence/master/language/resource.language.ca_es/strings.po",
+            "type": "file",
+            "target": "kodi-confluence-ca.po"
         }
     }
 }

--- a/cfg/projects/Kodi.json
+++ b/cfg/projects/Kodi.json
@@ -6,12 +6,12 @@
         "kodi-main": {
             "url": "https://github.com/xbmc/xbmc.git",
             "type": "git",
-            "pattern": ".*\/resource\\.language\\.ca_es\/strings.po"
+            "pattern": ".*\/resource\\.language\\.ca_es\/strings\\.po"
         },
         "kodi-main2": {
             "url": "https://github.com/xbmc/xbmc.git",
             "type": "git",
-            "pattern": ".*\/language\/Catalan\/strings.po"
+            "pattern": ".*\/language\/Catalan\/strings\\.po"
         },
         "kodi-confluence": {
             "url": "https://raw.githubusercontent.com/xbmc/skin.confluence/master/language/resource.language.ca_es/strings.po",

--- a/cfg/projects/Kodi.json
+++ b/cfg/projects/Kodi.json
@@ -4,19 +4,9 @@
     "projectweb": "https://kodi.tv/",
     "fileset": {
         "kodi-main": {
-            "url": "https://app.transifex.com/teamxbmc/kodi-main/",
-            "type": "transifex",
-            "pattern": ".*?ca(_ES)?.po"
-        },
-        "kodi-addons": {
-            "url": "https://app.transifex.com/teamxbmc/kodi-addons/",
-            "type": "transifex",
-            "pattern": ".*?ca(_ES)?.po"
-        },
-        "kodi-skins": {
-            "url": "https://app.transifex.com/teamxbmc/kodi-skins/",
-            "type": "transifex",
-            "pattern": ".*?ca(_ES)?.po"
+            "url": "https://github.com/xbmc/xbmc.git",
+            "type": "git",
+            "pattern": ".*?/resource.language.ca_es/strings.po"
         }
     }
 }

--- a/cfg/projects/Kodi.json
+++ b/cfg/projects/Kodi.json
@@ -6,12 +6,7 @@
         "kodi-main": {
             "url": "https://github.com/xbmc/xbmc.git",
             "type": "git",
-            "pattern": ".*\/resource\\.language\\.ca_es\/strings\\.po"
-        },
-        "kodi-main2": {
-            "url": "https://github.com/xbmc/xbmc.git",
-            "type": "git",
-            "pattern": ".*\/language\/Catalan\/strings\\.po"
+            "pattern": ".*/resource\\.language\\.ca_es/strings\\.po|.*/language/Catalan/strings.po"
         },
         "kodi-confluence": {
             "url": "https://raw.githubusercontent.com/xbmc/skin.confluence/master/language/resource.language.ca_es/strings.po",


### PR DESCRIPTION
Semblant a #271, això hauria d'importar moltes cadenes però falla alguna cosa (només n'importa 344):

```
$ python3 builder.py -pKodi
Translation memory builder version 0.1
Use --help for assistance
Projects defined in the projects configuration directory 223
S'està clonant a «_git»...
remote: Enumerating objects: 11714, done.
remote: Counting objects: 100% (11714/11714), done.
remote: Compressing objects: 100% (8493/8493), done.
remote: Total 11714 (delta 2364), reused 6446 (delta 1696), pack-reused 0
S'estan rebent objectes: 100% (11714/11714), 51.19 MiB | 19.67 MiB/s, fet.
S'estan resolent les diferències: 100% (2364/2364), fet.
S'estan actualitzant els fitxers: 100% (9723/9723), fet.
sh: a2po: command not found
Projects. Added into tots-tm.po a total of 0 words from 0 projects. Skipped 1 project(s) with 1927 words due to license incompatibility
Projects clean up:0
processing 1 files...
[###########################################] 100%
Kodi project. 344 translated strings, words 1927
Project.get_words_entries exception output/tots-tm.po
Translation memory for all projects is empty. No projects were added.
Time used to build memories: 0:00:10.254480
``` 


Que em falti `a2po` deu ser un altre problema sense relació