### PR TITLE
WinSCP: new project

### DIFF
--- a/cfg/projects/WinSCP.json
+++ b/cfg/projects/WinSCP.json
@@ -1,0 +1,13 @@
+{
+    "project": "WinSCP",
+    "license" : "GPL-3.0-or-later",
+    "projectweb": "https://winscp.net/eng/translations.php",
+    "fileset": {
+        "WinSCP": {
+            "url": "https://github.com/pereorga/software-translations.git",
+            "type": "git",
+            "duplicates" : "msgctxt",
+            "pattern": ".*?/winscp/.*?"
+        }
+    }
+}


### PR DESCRIPTION
```
$ python3 builder.py -p"WinSCP"
Translation memory builder version 0.1
Use --help for assistance
Projects defined in the projects configuration directory 226
S'està clonant a «_git»...
remote: Enumerating objects: 219, done.
remote: Counting objects: 100% (219/219), done.
remote: Compressing objects: 100% (200/200), done.
remote: Total 219 (delta 34), reused 120 (delta 18), pack-reused 0
S'estan rebent objectes: 100% (219/219), 823.84 KiB | 3.39 MiB/s, fet.
S'estan resolent les diferències: 100% (34/34), fet.
Projects. Added into tots-tm.po a total of 17808 words from 1 projects. Skipped 0 project(s) with 0 words due to license incompatibility
Projects clean up:0
processing 1 files...
[###########################################] 100%
processing 1 files...
[###########################################] 100%
WinSCP project. 2685 translated strings, words 17808
Translation memory for all projects: 2685 translated strings, words 17808
Time used to build memories: 0:00:02.160444
```

Com sempre, l'script d'obtenció i conversió que faig servir és simple (però una mica específic): https://github.com/pereorga/software-translations/blob/master/winscp/generate.sh