### PR TITLE
PrestaShop: new project

### DIFF
--- a/cfg/projects/PrestaShop.json
+++ b/cfg/projects/PrestaShop.json
@@ -1,0 +1,13 @@
+{
+    "project": "PrestaShop",
+    "license" : "OSL-3.0",
+    "projectweb": "https://crowdin.com/project/prestashop-official",
+    "fileset": {
+        "PrestaShop": {
+            "url": "https://github.com/pereorga/software-translations.git",
+            "type": "git",
+            "duplicates" : "msgctxt",
+            "pattern": ".*?/prestashop/.*?"
+        }
+    }
+}


### PR DESCRIPTION
Això importa 54534 paraules (és una traducció 100% completa).

He intentat primer afegir la importació automàtica de fitxers xlf i xliff directament a les memòries, però se m'ha complicat. La veritat és que és un format en desús, PrestaShop deu ser el projecte més rellevant que el fa servir.

Aquests altres projectes també fan servir XLF i XLIFF (de manera no tan modular), però les cadenes es converteixen en fuzzy amb Translate Toolkit. Puc mirar de fer una PR a Translate Toolkit després:

- https://raw.githubusercontent.com/Chocobozzz/PeerTube/develop/client/src/locale/angular.ca-ES.xlf
- https://raw.githubusercontent.com/sonata-project/SonataAdminBundle/master/src/Resources/translations/SonataAdminBundle.ca.xliff
- https://raw.githubusercontent.com/mihaelamj/openfoodfacts-ios/master/xliff/ca.xliff
- https://raw.githubusercontent.com/KnpLabs/KnpTimeBundle/master/translations/time.ca.xliff
