### PR TITLE
WireGuard: new project

### DIFF
--- a/cfg/projects/WireGuard.json
+++ b/cfg/projects/WireGuard.json
@@ -1,0 +1,15 @@
+{
+    "project": "WireGuard",
+    "license" : "MIT",
+    "projectweb": "https://crowdin.com/project/wireguard",
+    "fileset": {
+        "WireGuard-android": {
+            "url": "https://github.com/WireGuard/wireguard-android.git",
+            "type": "git"
+        },
+        "WireGuard-apple": {
+            "url": "https://github.com/WireGuard/wireguard-apple.git",
+            "type": "git"
+        }
+    }
+}

--- a/src/builder/convertfiles.py
+++ b/src/builder/convertfiles.py
@@ -342,5 +342,11 @@ class ConvertFiles:
                 if os.path.exists(src) and os.path.exists(tgt):
                     self._convert_apple_file(src, tgt, id)
                     id += 1
+                else:
+                    src = os.path.join(dir, "Base.lproj/Localizable.strings")
+                    tgt = os.path.join(dir, "ca.lproj/Localizable.strings")
+                    if os.path.exists(src) and os.path.exists(tgt):
+                        self._convert_apple_file(src, tgt, id)
+                        id += 1
 
         logging.info("convert Apple directory: {0}".format(self.convert_dir))


### PR DESCRIPTION
- Faltaria la part Windows, que fa servir fitxers INI potser personalitzats: https://github.com/WireGuard/wireguard-windows/tree/master/locales/
- He provat la integració Crowdin i en aquest cas m'ha semblat que no ajudava en res
- En el cas d'Apple, he hagut de considerar el cas que el directori de la llengua original sigui "Base.lproj" en comptes de "en.lproj". Diria que ho he vist a més llocs. No estic segur que el codi sigui òptim, però funciona