### PR TITLE
VLC: add iOS translation

### DIFF
--- a/cfg/projects/VLC.json
+++ b/cfg/projects/VLC.json
@@ -1,5 +1,5 @@
 {
-    "project": "VLC media player",
+    "project": "VLC",
     "license" : "LGPL-2.1-or-later",
     "projectweb": "https://www.softcatala.org/projectes/vlc/", 
     "softcatala": true, 
@@ -12,6 +12,12 @@
         "VLC-android": {
             "url": "https://code.videolan.org/videolan/vlc-android.git",
             "type": "git"
+        },
+        "VLC-ios": {
+            "url": "https://github.com/pereorga/software-translations.git",
+            "type": "git",
+            "duplicates" : "msgctxt",
+            "pattern": ".*?/vlc-ios/.*?"
         },
         "VLMC": {
             "url": "https://code.videolan.org/videolan/vlmc/-/raw/master/ts/vlmc_ca_ES.ts",


### PR DESCRIPTION
Closes #263. Temporalment, a l'espera de https://github.com/translate/translate/issues/4989 (que veig poc probable). Tampoc és segur que puguem generalitzar-ho fàcilment, doncs la codificació pot variar per fitxer i no per projecte.

Mitiga també #281, encara que en aquest cas no sigui significatiu (només 3 cadenes).

https://github.com/pereorga/software-translations/blob/master/vlc-ios/generate.sh

També arregla la importació de VLMC, pel fet de treure l'espai al nom del projecte. No estic segur si això de l'espai és una regressió que afecta a més projectes, o potser només em passa a mi al Mac.

