### PR TITLE
Godot Engine: fix import

### DIFF
--- a/cfg/projects/GodotEngine.json
+++ b/cfg/projects/GodotEngine.json
@@ -3,7 +3,7 @@
     "license": "MIT",
     "projectweb": "https://godotengine.org/",
     "fileset": {
-        "Godot Engine": {
+        "GodotEngine": {
             "url": "https://raw.githubusercontent.com/godotengine/godot/master/editor/translations/editor/ca.po",
             "target": "godot.po",
             "type": "file"


### PR DESCRIPTION
Arregla el problema d'importació reportat a https://static.softcatala.org/memories/builder-error.log.

Entenc que al fileset millor no tenir-hi espais.