### PR TITLE
KDE project: add new version (KF6)

### DIFF
--- a/cfg/projects/KDE.json
+++ b/cfg/projects/KDE.json
@@ -10,6 +10,14 @@
         "documentation-kf5": {
             "url": "svn://anonsvn.kde.org/home/kde/trunk/l10n-kf5/ca/docmessages/",
             "type": "subversion"
+        },
+        "gui-kf6": {
+            "url": "svn://anonsvn.kde.org/home/kde/trunk/l10n-kf6/ca/messages/",
+            "type": "subversion"
+        },
+        "documentation-kf6": {
+            "url": "svn://anonsvn.kde.org/home/kde/trunk/l10n-kf6/ca/docmessages/",
+            "type": "subversion"
         }
     }
 }


### PR DESCRIPTION
This new cfg file for KDE will download all Catalan translations from KDE branches (trunk-KF5 & trunk-KF6; stable is included in trunk-KF5). Now, we will get about 3.278.000 words.  