### PR TITLE
fix(OnionShare): import only Catalan translations

### DIFF
--- a/cfg/projects/OnionShare.json
+++ b/cfg/projects/OnionShare.json
@@ -5,7 +5,8 @@
     "fileset": {
         "OnionShare": {
             "url": "https://github.com/onionshare/onionshare",
-            "type": "git"
+            "type": "git",
+            "pattern": ".*/locale/ca/.*\\.po|.*/resources/locale/.*"
         }
     }
 }


### PR DESCRIPTION
No sabia que el repositori també tenia fitxers PO, el que fa que s'hagin importat les traduccions de tots els idiomes.