### PR TITLE
Organic Maps: remove files with duplicated strings

### DIFF
--- a/cfg/projects/OrganicMaps.json
+++ b/cfg/projects/OrganicMaps.json
@@ -7,11 +7,6 @@
             "url": "https://github.com/organicmaps/organicmaps.git",
             "type": "git"
         },
-        "organicmaps-twine": {
-            "url": "https://raw.githubusercontent.com/pereorga/software-translations/master/organicmaps/ca.po",
-            "type": "file",
-            "target": "organicmaps-twine-ca.po"
-        },
         "organicmaps-website": {
             "url": "https://raw.githubusercontent.com/organicmaps/organicmaps.github.io/master/po/content.ca.po",
             "type": "file",


### PR DESCRIPTION
Resulta que no cal convertir els fitxers font (Twine) si ja s'incorporen les cadenes de les aplicacions mòbils