### PR TITLE
Keycloak: new project

### DIFF
--- a/cfg/projects/Keycloak.json
+++ b/cfg/projects/Keycloak.json
@@ -1,0 +1,14 @@
+{
+    "project": "Keycloak",
+    "license": "Apache-2.0",
+    "projectweb": "https://github.com/keycloak/keycloak",
+    "softcatala": true,
+    "fileset": {
+        "Keycloak": {
+            "url": "https://github.com/pereorga/software-translations.git",
+            "type": "git",
+            "duplicates": "msgctxt",
+            "pattern": ".*?/keycloak/.*?"
+        }
+    }
+}


### PR DESCRIPTION
Crec que hi ha un bug i el `pattern` no delimita bé el camí, important cadenes dels directoris superiors (HomeAssistant). No sé si és només al meu Mac, però no és específic d'aquesta PR, també em passa a altres projectes (p. ex. OpenEmu). Si fos així, potser estaria important cadenes duplicades.