### PR TITLE
BleachBit: move to custom repo and update license

### DIFF
--- a/cfg/projects/BleachBit.json
+++ b/cfg/projects/BleachBit.json
@@ -1,6 +1,6 @@
 {
     "project": "BleachBit",
-    "license": "GPL-3.0-only",
+    "license": "GPL-3.0-or-later",
     "projectweb": "https://www.bleachbit.org/contribute/translate",
     "fileset": {
         "BleachBit": {

--- a/cfg/projects/BleachBit.json
+++ b/cfg/projects/BleachBit.json
@@ -4,7 +4,7 @@
     "projectweb": "https://www.bleachbit.org/contribute/translate",
     "fileset": {
         "BleachBit": {
-            "url": "https://hosted.weblate.org/download/bleachbit/main/ca/",
+            "url": "https://raw.githubusercontent.com/pereorga/software-translations/master/bleachbit/ca.po",
             "type": "file",
             "target": "bleachbit-ca.po"
         }


### PR DESCRIPTION
Sembla que la solució més robusta seria https://github.com/izimobil/polib/issues/148. Es pot tornar a on era quan ho arreglin, o si mai arreglen el fitxer del BleachBit.

