### PR TITLE
Anna's Archive: disable project

### DIFF
--- a/cfg/projects/AnnasArchive.json
+++ b/cfg/projects/AnnasArchive.json
@@ -9,5 +9,6 @@
             "duplicates": "msgctxt",
             "target": "annasarchive-ca.po"
         }
-    }
+    },
+    "disabled": true
 }


### PR DESCRIPTION
No és accessible (depenent de l'ISP, suposo)

He trobat el mirror https://software.annas-archive.se/AnnaArchivist/annas-archive/-/raw/main/allthethings/translations/ca/LC_MESSAGES/messages.po, però veig que el fitxer és monolingüe (fa servir etiquetes internes com a identificador, en comptes de les cadenes angleses).

