### PR TITLE
Mistyping of PROPRIETARY in projects.py

### DIFF
--- a/src/builder/projects.py
+++ b/src/builder/projects.py
@@ -155,7 +155,7 @@ class Projects(object):
         skipped_prjs = 0
         skipped_words = 0
         for project in self.projects:
-            if project.license.lower() == Licenses().PROPIETARY:
+            if project.license.lower() == Licenses().PROPRIETARY:
                 logging.debug(
                     f"Projects. Skipping {project.name} into {self.tm_file} memory"
                 )


### PR DESCRIPTION
Correcting mistyping of PROPRIETARY as I got :

`File "/home/bof/translation-memory-tools/src/builder/projects.py", line 158, in create_tm_for_all_projects
    if project.license.lower() == Licenses().PROPIETARY:
                                  ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Licenses' object has no attribute 'PROPIETARY'. Did you mean: 'PROPRIETARY'? `