### PR TITLE
Fix: Remove broken symlinks when building filesets

### DIFF
--- a/src/builder/fileset.py
+++ b/src/builder/fileset.py
@@ -216,5 +216,5 @@ class FileSet:
         findFiles = FindFiles()
 
         for filename in findFiles.find_recursive(self.temp_dir, "*"):
-            if re.match(self.pattern, filename) is None and os.path.exists(filename):
+            if re.match(self.pattern, filename) is None and os.path.lexists(filename):
                 os.remove(filename)


### PR DESCRIPTION
If a project's fileset contains a translation file which is a symlink, but the symlink's target file is removed (because it does not match the fileset's pattern), the symlink breaks. We rely on `os.path.exists(path)` to remove unnecessary files, but this function returns `False` if the file is a broken symlink [[1](https://docs.python.org/3/library/os.path.html#os.path.exists)]. As a result, broken symlinks are not removed and we get a bunch of warnings when building certain TMs (observed in the MetaBrainz project (#440).

This changes the function to `os.path.lexists(path)` instead, which does return `True` for broken symlinks [[2](https://docs.python.org/3/library/os.path.html#os.path.exists)] and allows the TM builder to properly remove them.